### PR TITLE
node: Add support for custom clients

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -42,6 +42,18 @@ func NewClient(ctx context.Context, rawURL string) (Client, error) {
 	}, nil
 }
 
+func NewCustomClient(requester Requester, subscriber Subscriber) (Client, error) {
+	t, err := newCustomTransport(requester, subscriber)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create custom transport")
+	}
+
+	return &client{
+		transport: t,
+		rawURL:    "",
+	}, nil
+}
+
 type transport interface {
 	Requester
 	Subscriber

--- a/node/custom.go
+++ b/node/custom.go
@@ -1,0 +1,39 @@
+package node
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/INFURA/go-ethlibs/jsonrpc"
+)
+
+type customTransport struct {
+	requester  Requester
+	subscriber Subscriber
+}
+
+func (t *customTransport) Request(ctx context.Context, r *jsonrpc.Request) (*jsonrpc.RawResponse, error) {
+	return t.requester.Request(ctx, r)
+}
+
+func (t *customTransport) Subscribe(ctx context.Context, r *jsonrpc.Request) (Subscription, error) {
+	if t.subscriber == nil {
+		return nil, errors.New("subscriptions not supported over this transport")
+	}
+
+	return t.subscriber.Subscribe(ctx, r)
+}
+
+func (t *customTransport) IsBidirectional() bool {
+	return t.subscriber != nil
+}
+
+func newCustomTransport(requester Requester, subscriber Subscriber) (*customTransport, error) {
+	t := customTransport{
+		requester:  requester,
+		subscriber: subscriber,
+	}
+
+	return &t, nil
+}


### PR DESCRIPTION
This adds support for building custom clients that implement the full `node.Client` interface by just supplying a `node.Requester` and optional `node.Subscriber` interface implementations.

This can be used for doing custom routing, for example to build a client which routes requests to different backends based on the JSONRPC request method (e.g. `parity_*` methods to a parity node, while sending other RPCs to geth).