### PR TITLE
node: Fix missing return in bidirectional transport during read error

### DIFF
--- a/node/loop.go
+++ b/node/loop.go
@@ -101,6 +101,8 @@ func (t *loopingTransport) loop() {
 					log.Printf("[DEBUG] Context cancelled during read")
 					return nil
 				}
+
+				return errors.Wrap(err, "error reading message")
 			}
 
 			if payload == nil {


### PR DESCRIPTION
Found a case where we weren't propagating the error during a read, which could lead to, for example, a `panic` in gorilla websocket when trying to read on the connection again:

```
panic: repeated read on failed websocket connection
goroutine 48 [running]:
github.com/gorilla/websocket.(*Conn).NextReader(0xc00033ab00, 0x1b30910, 0xc000433d98, 0x4de1bb, 0xc000462050, 0x0)
	/go/src/github.com/INFURA/off-chain-logs/vendor/github.com/gorilla/websocket/conn.go:1001 +0x353
github.com/INFURA/go-ethlibs/node.newWebsocketTransport.func1(0xc000462040, 0x0, 0x0, 0x13b7a60, 0xc000d35360)
	/go/src/github.com/INFURA/off-chain-logs/vendor/github.com/INFURA/go-ethlibs/node/websocket.go:25 +0x2e
```