### PR TITLE
Refactor subscriptions to avoid issues with channel ownership

### DIFF
--- a/node/_example/main.go
+++ b/node/_example/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"github.com/INFURA/go-ethlibs/eth"
+	"github.com/INFURA/go-ethlibs/jsonrpc"
 	"github.com/INFURA/go-ethlibs/node"
 	"log"
 )
@@ -36,14 +37,17 @@ func main() {
 	log.Printf("[INFO] Current Block number: %d", num)
 
 	if client.IsBidirectional() {
-		log.Printf("[INFO] Client should support subscriptions, attempting newHeads")
+		log.Printf("[INFO] Client supports subscriptions")
+		log.Printf("[INFO] starting newHeads subscription...")
 		newHeads, err := client.SubscribeNewHeads(ctx)
 		if err != nil {
 			log.Fatalf("[FATAL] NewHeads error: %v", err)
 		}
 
+		log.Printf("[INFO] newHeads subscription id %s", newHeads.ID())
+		log.Printf("[INFO] waiting for newHeads subscription notifications...")
+		received := 0
 		for notif := range newHeads.Ch() {
-			log.Printf("[INFO] %s", string(notif.Params))
 			newHead := eth.NewHeadsNotificationParams{}
 			err := notif.UnmarshalParamsInto(&newHead)
 			if err != nil {
@@ -51,7 +55,39 @@ func main() {
 			}
 
 			log.Printf("[INFO] got notification for newHead %v %v", newHead.Result.Number.UInt64(), newHead.Result.Hash)
-			return
+
+			received += 1
+			// unsubscribe after 3rd block (just as a test)
+			if received == 3 {
+				if err := newHeads.Unsubscribe(ctx); err != nil {
+					log.Fatalf("[FATAL] error unsubscribing newHeads: %v", err)
+				}
+			}
+		}
+
+		// we'll do a logs subscription as soon as the newHeads one is done
+		log.Printf("[INFO] starting logs subscription...")
+		logs, err := client.Subscribe(ctx, &jsonrpc.Request{
+			JSONRPC: "2.0",
+			Method:  "eth_subscribe",
+			ID: jsonrpc.ID{
+				Num: 2,
+			},
+			Params: jsonrpc.MustParams("logs", &eth.LogFilter{}),
+		})
+		if err != nil {
+			log.Fatalf("[FATAL] Logs subscription error: %v", err)
+		}
+
+		log.Printf("[INFO] logs subscription id %s", logs.ID())
+		log.Printf("[INFO] waiting for logs subscription notification...")
+		for notif := range logs.Ch() {
+			log.Printf("[INFO] Logs result: %s", string(notif.Params))
+
+			// unsubscribe after first logs (just as a test)
+			if err := logs.Unsubscribe(ctx); err != nil {
+				log.Fatalf("[FATAL] error unsubscribing logs: %v", err)
+			}
 		}
 	}
 }

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -59,8 +59,6 @@ type Client interface {
 type Subscription interface {
 	Response() *jsonrpc.RawResponse
 	ID() string
-	Ch() chan *jsonrpc.Notification
+	Ch() <-chan *jsonrpc.Notification
 	Unsubscribe(ctx context.Context) error
-	Done() <-chan struct{}
-	Err() error
 }

--- a/node/loop.go
+++ b/node/loop.go
@@ -207,7 +207,7 @@ func (t *loopingTransport) loop() {
 					continue
 				}
 
-				func(n jsonrpc.Notification) {
+				go func(n jsonrpc.Notification) {
 					t.subscriptionsMu.RLock()
 					defer t.subscriptionsMu.RUnlock()
 					if subscription, ok := t.subscriptions[sp.Subscription]; ok {

--- a/node/loop.go
+++ b/node/loop.go
@@ -148,25 +148,16 @@ func (t *loopingTransport) loop() {
 
 					switch result := result.(type) {
 					case string:
-						subCtx, subCancel := context.WithCancel(t.ctx)
-
-						subscription := &subscription{
-							response:       &patchedResponse,
-							subscriptionID: result,
-							ch:             make(chan *jsonrpc.Notification),
-							conn:           t,
-							ctx:            subCtx,
-							cancel:         subCancel,
-						}
+						sub := newSubscription(&patchedResponse, result, t)
 						t.subscriptionsMu.Lock()
-						t.subscriptions[result] = subscription
+						t.subscriptions[result] = sub
 						t.subscriptionsMu.Unlock()
 
 						go func() {
 							select {
 							case <-ctx.Done():
 								return
-							case start.chResult <- subscription:
+							case start.chResult <- sub:
 								return
 							}
 						}()
@@ -216,20 +207,13 @@ func (t *loopingTransport) loop() {
 					continue
 				}
 
-				t.subscriptionsMu.RLock()
-				if subscription, ok := t.subscriptions[sp.Subscription]; ok {
-					go func(n *jsonrpc.Notification) {
-						_copy := *n
-						select {
-						case <-ctx.Done():
-							return
-						case subscription.ch <- &_copy:
-							return
-						}
-
-					}(msg)
-				}
-				t.subscriptionsMu.RUnlock()
+				func(n jsonrpc.Notification) {
+					t.subscriptionsMu.RLock()
+					defer t.subscriptionsMu.RUnlock()
+					if subscription, ok := t.subscriptions[sp.Subscription]; ok {
+						subscription.dispatch(ctx, n)
+					}
+				}(*msg)
 			}
 		}
 	})
@@ -243,6 +227,21 @@ func (t *loopingTransport) loop() {
 				b, err := json.Marshal(&r)
 				if err != nil {
 					return errors.Wrap(err, "error marshalling request for backend")
+				}
+
+				if r.Method == "eth_unsubscribe" {
+					// process the unsubscribe here just in case someone
+					// manually creates the eth_unsubscribe RPC versus calling subscription.Unsubscribe()
+					var id string
+					if r.Params.UnmarshalInto(&id) == nil {
+						log.Printf("[DEBUG] removing subscription id %s", id)
+						t.subscriptionsMu.Lock()
+						if sub, ok := t.subscriptions[id]; ok {
+							sub.stop(ctx)
+							delete(t.subscriptions, id)
+						}
+						t.subscriptionsMu.Unlock()
+					}
 				}
 
 				// log.Printf("[SPAM] Writing %s", string(b))
@@ -329,10 +328,8 @@ func (t *loopingTransport) loop() {
 	// let's clean up all the remaining subscriptions
 	t.subscriptionsMu.Lock()
 	for id, sub := range t.subscriptions {
-		sub.mu.Lock()
-		sub.err = err
-		sub.mu.Unlock()
-		sub.cancel()
+		// don't pass in our ctx here, it's already been stopped
+		sub.stop(context.Background())
 		delete(t.subscriptions, id)
 	}
 	t.subscriptionsMu.Unlock()

--- a/node/subscription.go
+++ b/node/subscription.go
@@ -108,11 +108,11 @@ func newSubscription(response *jsonrpc.RawResponse, id string, r Requester) *sub
 
 func (s *subscription) dispatch(ctx context.Context, n jsonrpc.Notification) {
 	// we've been given a notification that needs to be dispatched to notificationsCh
-	// however we can't do it directly here, sine we only want one goroutine sending
+	// however we can't do it directly here, since we only want one goroutine sending
 	// notifications on this channel, so that it can be stopped cleanly.
 	// Instead, we'll write it to an intermediate work/dispatch channel.
 	//
-	// Important note: the `n` argument to this function is intentional a a by-value copy
+	// Important note: the `n` argument to this function is intentionally a by-value copy
 	// of the full struct rahter than a pointer.  This is to ensure that this function owns
 	// the pointer that is written to the dispatch channel.
 

--- a/node/subscription.go
+++ b/node/subscription.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"encoding/json"
-	"sync"
 
 	"github.com/pkg/errors"
 
@@ -11,15 +10,13 @@ import (
 )
 
 type subscription struct {
-	response       *jsonrpc.RawResponse
-	subscriptionID string
-	ch             chan *jsonrpc.Notification
-
-	conn   Requester
-	ctx    context.Context
-	cancel context.CancelFunc
-	err    error
-	mu     sync.RWMutex
+	response        *jsonrpc.RawResponse
+	subscriptionID  string
+	notificationsCh chan *jsonrpc.Notification
+	dispatchCh      chan *jsonrpc.Notification
+	signalCh        chan struct{}
+	stoppedCh       chan struct{}
+	conn            Requester
 }
 
 func (s *subscription) Response() *jsonrpc.RawResponse {
@@ -30,8 +27,8 @@ func (s *subscription) ID() string {
 	return s.subscriptionID
 }
 
-func (s *subscription) Ch() chan *jsonrpc.Notification {
-	return s.ch
+func (s *subscription) Ch() <-chan *jsonrpc.Notification {
+	return s.notificationsCh
 }
 
 type SubscriptionParams struct {
@@ -54,22 +51,96 @@ func (s *subscription) Unsubscribe(ctx context.Context) error {
 	}
 
 	if response.Error != nil {
-		return errors.Errorf("%v", response.Error)
+		return errors.Errorf("%s", string(*response.Error))
 	}
 
-	s.cancel()
 	return nil
 }
 
-func (s *subscription) Done() <-chan struct{} {
-	return s.ctx.Done()
+func newSubscription(response *jsonrpc.RawResponse, id string, r Requester) *subscription {
+	s := subscription{
+		response:        response,
+		subscriptionID:  id,
+		notificationsCh: make(chan *jsonrpc.Notification),
+		dispatchCh:      make(chan *jsonrpc.Notification),
+		signalCh:        make(chan struct{}),
+		stoppedCh:       make(chan struct{}),
+		conn:            r,
+	}
+
+	// start a goroutine to move work from dispatchCh to notificationsCh
+	// we have to have this intermediate channel and the two
+	// signalling channels to make sure that everything
+	// is shut down in the proper order and no one tries writing
+	// to a closed channel.  See for example variant #5 on https://go101.org/article/channel-closing.html
+	go func() {
+		for {
+			select {
+			case <-s.signalCh:
+				// we've been signalled to stop.  Close the stopped channel so it
+				// signals to everyone we've already been stopped.
+				close(s.stoppedCh)
+
+				// then close the notifications channel so any consumers of
+				// subscription.Ch() are unblocked
+				close(s.notificationsCh)
+			case n := <-s.dispatchCh:
+				// we have a notification to dispatch to the external channel
+				select {
+				case s.notificationsCh <- n:
+					// we successfully dispatched the notification
+				case <-s.signalCh:
+					// we were told to stop while trying to write the notification
+					// Close the stopped channel so it signals to everyone we've
+					// already been stopped.
+					close(s.stoppedCh)
+
+					// then close the notifications channel so any consumers of
+					// subscription.Ch() are unblocked
+					close(s.notificationsCh)
+				}
+			}
+		}
+	}()
+
+	return &s
 }
 
-func (s *subscription) Err() error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if s.err != nil {
-		return s.err
+func (s *subscription) dispatch(ctx context.Context, n jsonrpc.Notification) {
+	// we've been given a notification that needs to be dispatched to notificationsCh
+	// however we can't do it directly here, sine we only want one goroutine sending
+	// notifications on this channel, so that it can be stopped cleanly.
+	// Instead, we'll write it to an intermediate work/dispatch channel.
+	//
+	// Important note: the `n` argument to this function is intentional a a by-value copy
+	// of the full struct rahter than a pointer.  This is to ensure that this function owns
+	// the pointer that is written to the dispatch channel.
+
+	select {
+	case <-ctx.Done():
+		// the parent context .dispatch was called ended, we can go ahead and give up
+		// on dispatching this notification
+		return
+	case s.dispatchCh <- &n:
+		// the notification is now in the internal dispatch channel and will be processed
+		// by the goroutine created in newSubscription above
+		return
+	case <-s.stoppedCh:
+		// this subscription has been stopped so we can abandon any writes to it
+		return
 	}
-	return s.ctx.Err()
+}
+
+func (s *subscription) stop(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		// the calling context has ended, presumably because the client is shutting down
+		return
+	case <-s.stoppedCh:
+		// we've been stopped already, presumably by another caller of .stop()
+		return
+	case s.signalCh <- struct{}{}:
+		// we successfully signalled to the newSubscription goroutine our desire to stop
+		return
+	}
 }


### PR DESCRIPTION
Ok, I believe this resolves the root issue(s) uncovered by @JeeChoi in #11, namely:

- subscription having it's own context and cancel routine was definitely odd
- the channel returned by `subscription.Ch()` was never closed

However, when adding code to close the channel, I realized there was a more fundamental issue, in that the channel was being written to by multiple go routines, so closing the channel could lead to race conditions where writes occurred after close, leading to panics.  After researching solutions, the one I ended up liking best was a modified version of the code in "variant 5" one this page: https://go101.org/article/channel-closing.html 

I added a fair amount of comments since the number of channels ballooned from one to four, and also wrapped all the logic in private methods and a constructor for subscription instead of sprinkling it through loop.go, so overall I hope the code is easier to read.  Finally, I added some rather contrived code to the example to show how unsubscribing can be used.

Ideally we'd have better test coverage for loop.go, but that would require either making httptest support websockets or writing a pretty extensive IPC-based mock, either one is something to consider for later but not something I think we have the bandwidth to tackle now.