### PR TITLE
node.Client: Allow setting request options (namely request.ID). Fixes #7.

### DIFF
--- a/jsonrpc/id.go
+++ b/jsonrpc/id.go
@@ -20,6 +20,20 @@ type ID struct {
 	IsString bool
 }
 
+func StringID(s string) ID {
+	return ID{
+		Str:      s,
+		IsString: true,
+	}
+}
+
+func IntID(i uint64) ID {
+	return ID{
+		Num:      i,
+		IsString: false,
+	}
+}
+
 func (id ID) String() string {
 	if id.IsString {
 		return strconv.Quote(id.Str)

--- a/node/_example/main.go
+++ b/node/_example/main.go
@@ -54,7 +54,17 @@ func main() {
 				log.Fatalf("[FATAL] Cannot parse newHeads params: %v", err)
 			}
 
-			log.Printf("[INFO] got notification for newHead %v %v", newHead.Result.Number.UInt64(), newHead.Result.Hash)
+			// get the full block details, using a custom jsonrpc ID as a test
+			block, err := client.BlockByHash(
+				ctx, newHead.Result.Hash.String(),
+				true,
+				node.WithRequestID(jsonrpc.ID{Str: "foo"}),
+			)
+			if err != nil {
+				log.Fatalf("[FATAL] Block for newHead notification not found: %v", err)
+			}
+
+			log.Printf("[INFO] got notification for new block %v %v", block.Number.UInt64(), block.Hash)
 
 			received += 1
 			// unsubscribe after 3rd block (just as a test)

--- a/node/_example/main.go
+++ b/node/_example/main.go
@@ -56,9 +56,8 @@ func main() {
 
 			// get the full block details, using a custom jsonrpc ID as a test
 			block, err := client.BlockByHash(
-				ctx, newHead.Result.Hash.String(),
+				node.ContextWithRequestID(ctx, jsonrpc.StringID("test")), newHead.Result.Hash.String(),
 				true,
-				node.WithRequestID(jsonrpc.StringID("foo")),
 			)
 			if err != nil {
 				log.Fatalf("[FATAL] Block for newHead notification not found: %v", err)

--- a/node/_example/main.go
+++ b/node/_example/main.go
@@ -58,7 +58,7 @@ func main() {
 			block, err := client.BlockByHash(
 				ctx, newHead.Result.Hash.String(),
 				true,
-				node.WithRequestID(jsonrpc.ID{Str: "foo"}),
+				node.WithRequestID(jsonrpc.StringID("foo")),
 			)
 			if err != nil {
 				log.Fatalf("[FATAL] Block for newHead notification not found: %v", err)

--- a/node/context.go
+++ b/node/context.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	"context"
+
+	"github.com/INFURA/go-ethlibs/jsonrpc"
+)
+
+type contextKey string
+
+func ContextWithRequestID(parent context.Context, id jsonrpc.ID) context.Context {
+	return context.WithValue(parent, contextKey("id"), &id)
+}
+
+func requestIDFromContext(ctx context.Context) *jsonrpc.ID {
+	if id, ok := ctx.Value(contextKey("id")).(*jsonrpc.ID); ok {
+		return id
+	}
+
+	return nil
+}

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -26,31 +26,31 @@ type Client interface {
 	URL() string
 
 	// BlockNumber returns the current block number at head
-	BlockNumber(ctx context.Context) (uint64, error)
+	BlockNumber(ctx context.Context, options ...RequestOption) (uint64, error)
 
 	// BlockByNumber can be used to get a block by its number
-	BlockByNumber(ctx context.Context, number uint64, full bool) (*eth.Block, error)
+	BlockByNumber(ctx context.Context, number uint64, full bool, options ...RequestOption) (*eth.Block, error)
 
 	// BlockByNumberOrTag can be used to get a block by its number or tag (e.g. latest)
-	BlockByNumberOrTag(ctx context.Context, numberOrTag eth.BlockNumberOrTag, full bool) (*eth.Block, error)
+	BlockByNumberOrTag(ctx context.Context, numberOrTag eth.BlockNumberOrTag, full bool, options ...RequestOption) (*eth.Block, error)
 
 	// BlockByHash can be used to get a block by its hash
-	BlockByHash(ctx context.Context, hash string, full bool) (*eth.Block, error)
+	BlockByHash(ctx context.Context, hash string, full bool, options ...RequestOption) (*eth.Block, error)
 
 	// TransactionByHash can be used to get transaction by its hash
-	TransactionByHash(ctx context.Context, hash string) (*eth.Transaction, error)
+	TransactionByHash(ctx context.Context, hash string, options ...RequestOption) (*eth.Transaction, error)
 
 	// SubscribeNewHeads initiates a subscription for newHead events
-	SubscribeNewHeads(ctx context.Context) (Subscription, error)
+	SubscribeNewHeads(ctx context.Context, options ...RequestOption) (Subscription, error)
 
 	// SubscribeNewPendingTransactions initiates a subscription for newPendingTransaction events
-	SubscribeNewPendingTransactions(ctx context.Context) (Subscription, error)
+	SubscribeNewPendingTransactions(ctx context.Context, options ...RequestOption) (Subscription, error)
 
 	// TransactionReceipt can be used to get a TransactionReceipt for a particular transaction
-	TransactionReceipt(ctx context.Context, hash string) (*eth.TransactionReceipt, error)
+	TransactionReceipt(ctx context.Context, hash string, options ...RequestOption) (*eth.TransactionReceipt, error)
 
 	// Logs returns an array of Logs matching the passed in filter
-	Logs(ctx context.Context, filter eth.LogFilter) ([]eth.Log, error)
+	Logs(ctx context.Context, filter eth.LogFilter, options ...RequestOption) ([]eth.Log, error)
 
 	// IsBidirectional returns true if the under laying transport supports bidirectional features such as subscriptions
 	IsBidirectional() bool
@@ -61,4 +61,12 @@ type Subscription interface {
 	ID() string
 	Ch() <-chan *jsonrpc.Notification
 	Unsubscribe(ctx context.Context) error
+}
+
+type RequestOption func(r *jsonrpc.Request)
+
+func WithRequestID(id jsonrpc.ID) RequestOption {
+	return func(r *jsonrpc.Request) {
+		r.ID = id
+	}
 }

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -26,31 +26,31 @@ type Client interface {
 	URL() string
 
 	// BlockNumber returns the current block number at head
-	BlockNumber(ctx context.Context, options ...RequestOption) (uint64, error)
+	BlockNumber(ctx context.Context) (uint64, error)
 
 	// BlockByNumber can be used to get a block by its number
-	BlockByNumber(ctx context.Context, number uint64, full bool, options ...RequestOption) (*eth.Block, error)
+	BlockByNumber(ctx context.Context, number uint64, full bool) (*eth.Block, error)
 
 	// BlockByNumberOrTag can be used to get a block by its number or tag (e.g. latest)
-	BlockByNumberOrTag(ctx context.Context, numberOrTag eth.BlockNumberOrTag, full bool, options ...RequestOption) (*eth.Block, error)
+	BlockByNumberOrTag(ctx context.Context, numberOrTag eth.BlockNumberOrTag, full bool) (*eth.Block, error)
 
 	// BlockByHash can be used to get a block by its hash
-	BlockByHash(ctx context.Context, hash string, full bool, options ...RequestOption) (*eth.Block, error)
+	BlockByHash(ctx context.Context, hash string, full bool) (*eth.Block, error)
 
 	// TransactionByHash can be used to get transaction by its hash
-	TransactionByHash(ctx context.Context, hash string, options ...RequestOption) (*eth.Transaction, error)
+	TransactionByHash(ctx context.Context, hash string) (*eth.Transaction, error)
 
 	// SubscribeNewHeads initiates a subscription for newHead events
-	SubscribeNewHeads(ctx context.Context, options ...RequestOption) (Subscription, error)
+	SubscribeNewHeads(ctx context.Context) (Subscription, error)
 
 	// SubscribeNewPendingTransactions initiates a subscription for newPendingTransaction events
-	SubscribeNewPendingTransactions(ctx context.Context, options ...RequestOption) (Subscription, error)
+	SubscribeNewPendingTransactions(ctx context.Context) (Subscription, error)
 
 	// TransactionReceipt can be used to get a TransactionReceipt for a particular transaction
-	TransactionReceipt(ctx context.Context, hash string, options ...RequestOption) (*eth.TransactionReceipt, error)
+	TransactionReceipt(ctx context.Context, hash string) (*eth.TransactionReceipt, error)
 
 	// Logs returns an array of Logs matching the passed in filter
-	Logs(ctx context.Context, filter eth.LogFilter, options ...RequestOption) ([]eth.Log, error)
+	Logs(ctx context.Context, filter eth.LogFilter) ([]eth.Log, error)
 
 	// IsBidirectional returns true if the under laying transport supports bidirectional features such as subscriptions
 	IsBidirectional() bool
@@ -61,12 +61,4 @@ type Subscription interface {
 	ID() string
 	Ch() <-chan *jsonrpc.Notification
 	Unsubscribe(ctx context.Context) error
-}
-
-type RequestOption func(r *jsonrpc.Request)
-
-func WithRequestID(id jsonrpc.ID) RequestOption {
-	return func(r *jsonrpc.Request) {
-		r.ID = id
-	}
 }


### PR DESCRIPTION
This fixes #7 by allowing the node.Client consumer to specify a request ID on the context passed into client methods, for example:

```golang
block, err := client.BlockByHash(node.ContextWithRequestID(jsonrpc.StringID("test")), hash, true)
```

This is a requirement for some internal systems where we want to start using a custom request ID for routing inside the request receiver, even though that's not really the intended use of `id` (https://www.jsonrpc.org/specification#request_object) it beats adding any other metadata to the requests.

It's also useful for clients that want to use custom IDs to assist with general observability (e.g. using an auto-incrementing ID to track request counts, etc.).

Anyways, happy to discuss alternative implementations (ed: which were discussed and we landed on contexts).