### PR TITLE
Fix race conditions in websocket transport.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/btcsuite/btcd v0.0.0-20190614013741-962a206e94e9
 	github.com/gorilla/websocket v1.4.1
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c

--- a/go.sum
+++ b/go.sum
@@ -13,12 +13,12 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/node/websocket.go
+++ b/node/websocket.go
@@ -44,7 +44,7 @@ func newWebsocketTransport(ctx context.Context, addr *url.URL) (transport, error
 		return err
 	}
 
-	t := ipcTransport{
+	t := websocketTransport{
 		loopingTransport: newLoopingTransport(ctx, wsConn, readMessage, writeMessage),
 	}
 


### PR DESCRIPTION
This PR fixes some race conditions found in the websocket node.Client transport:

- Turns out gorilla/websocket is not concurrency safe, even though it implements functions from stdlib's `net.Conn` which is documented as concurrency safe.  As mentioned in the gorilla docs the read and write groupings of methods need to be protected, so I added `readMu` and `writeMu`.

- in loopingTransport.Request, we weren't actually copying the input Request when adding it to the outgoingRequest struct.  At first I tried basically `outgoing.request = &*r`, but even that's not enough: `jsonrpc.Request.Params` is a slice, so Go just copies over the slice address, so we have to do a "deep copy" and jinzhu's copier package seems to be the most commonly used way to do that.

- Stop closing the outboundRequest.chResponse and chError channels when they could still be written to if a response was in-flight.  Instead I added a new `chAbandoned` that's closed when the original request is cancelled; there's no reason to close those channels since they are only used internally and the consumer is not expecting them to close.

I also made one other non-race related change, in that if the outgoing request is using a string ID, we simply append our proxied id to it rather than replace it, and keep the ID a string.  I'd _love_ to figure out a way to remove the need to proxy the request IDs at all, but that would require either the node.Client user always using unique IDs, or for the websocket transport to handle requests sequentially when the IDs aren't unique, both of which seem kind of burdensome.
