### PR TITLE
Use Close instead of Deadlines, use DialContext.

### DIFF
--- a/node/ipc.go
+++ b/node/ipc.go
@@ -10,7 +10,8 @@ import (
 )
 
 func newIPCTransport(ctx context.Context, parsedURL *url.URL) (*ipcTransport, error) {
-	conn, err := net.Dial("unix", parsedURL.String())
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", parsedURL.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect over IPC")
 	}

--- a/node/loop.go
+++ b/node/loop.go
@@ -106,7 +106,6 @@ func (t *loopingTransport) loop() {
 			t.readMu.Unlock()
 			if err != nil {
 				if ctx.Err() == context.Canceled {
-					log.Printf("[DEBUG] Context cancelled during read")
 					return nil
 				}
 
@@ -262,7 +261,6 @@ func (t *loopingTransport) loop() {
 				t.writeMu.Unlock()
 				if err != nil {
 					if ctx.Err() == context.Canceled {
-						log.Printf("[DEBUG] Context cancelled during write")
 						return nil
 					}
 
@@ -322,18 +320,11 @@ func (t *loopingTransport) loop() {
 		}
 	})
 
-	// Aborter
+	// Closer
 	g.Go(func() error {
 		select {
 		case <-ctx.Done():
-			log.Printf("[DEBUG] Context done, setting deadlines to now")
-			t.readMu.Lock()
-			_ = t.conn.SetReadDeadline(time.Now())
-			t.readMu.Unlock()
-
-			t.writeMu.Lock()
-			_ = t.conn.SetWriteDeadline(time.Now())
-			t.writeMu.Unlock()
+			_ = t.conn.Close()
 		}
 
 		return nil

--- a/node/websocket.go
+++ b/node/websocket.go
@@ -16,7 +16,7 @@ type websocketTransport struct {
 // newWebsocketTransport creates a Connection to the passed in URL.  Use the supplied Context to shutdown the connection by
 // cancelling or otherwise aborting the context.
 func newWebsocketTransport(ctx context.Context, addr *url.URL) (transport, error) {
-	wsConn, _, err := websocket.DefaultDialer.Dial(addr.String(), nil)
+	wsConn, _, err := websocket.DefaultDialer.DialContext(ctx, addr.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I found after some more testing the gorilla can deadlock with the changes from #18.  Luckily, I found that the gorilla docs mention that `.Close()` _is_ safe to call concurrently from other goroutines, so this seems like a cleaner approach.

While debugging I also changed to using `.DialContext` since we have a context, and removed some spammy log messages.