### PR TITLE
Make sure we return the correct ctx.Err

### DIFF
--- a/node/loop.go
+++ b/node/loop.go
@@ -364,7 +364,7 @@ func (t *loopingTransport) nextID(seed jsonrpc.ID) jsonrpc.ID {
 func (t *loopingTransport) Request(ctx context.Context, r *jsonrpc.Request) (*jsonrpc.RawResponse, error) {
 	select {
 	case <-t.ctx.Done():
-		return nil, errors.Wrap(ctx.Err(), "transport context finished")
+		return nil, errors.Wrap(t.ctx.Err(), "transport context finished")
 	default:
 		// transport context is still valid, we can process this request
 	}
@@ -388,7 +388,7 @@ func (t *loopingTransport) Request(ctx context.Context, r *jsonrpc.Request) (*js
 	case t.chOutboundRequests <- outbound:
 		// log.Printf("[SPAM] outbound request sent")
 	case <-t.ctx.Done():
-		return nil, errors.Wrap(ctx.Err(), "transport context finished waiting for response")
+		return nil, errors.Wrap(t.ctx.Err(), "transport context finished waiting for response")
 	case <-ctx.Done():
 		return nil, errors.Wrap(ctx.Err(), "context finished waiting for response")
 	}
@@ -399,7 +399,7 @@ func (t *loopingTransport) Request(ctx context.Context, r *jsonrpc.Request) (*js
 	case err := <-outbound.chError:
 		return nil, err
 	case <-t.ctx.Done():
-		return nil, errors.Wrap(ctx.Err(), "transport context finished waiting for response")
+		return nil, errors.Wrap(t.ctx.Err(), "transport context finished waiting for response")
 	case <-ctx.Done():
 		return nil, errors.Wrap(ctx.Err(), "context finished waiting for response")
 	}


### PR DESCRIPTION

I just ran into a corner case during a network issue when debugging locally that I'm pretty sure I traced back to this issue.

Normally `loopingTransport.ctx` and the `ctx` passed into `.Request` are the same, or at least in the same tree, but they don't have to be, so it's definitely a bug that we'd do `<-t.ctx.Done` but return `ctx.Err()`.  This led to the scenario where `.Request()` returned `(nil, nil)` which it shouldn't.