### PR TITLE
Fix potential data race in Quantity.DeepCopyInto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - go-mod-v1-{{ checksum "go.sum" }}
 
       - run: diff -u <(echo -n) <(gofmt -d .)
-      - run: go test -vet "all" -v ./...
+      - run: go test -race -vet "all" -v ./...
 
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/eth/quantity.go
+++ b/eth/quantity.go
@@ -127,6 +127,7 @@ func (q *Quantity) MarshalJSON() ([]byte, error) {
 // DeepCopyInto copies Quantity values into out
 func (q *Quantity) DeepCopyInto(out *Quantity) {
 	out.s = q.s
+	out.i = big.Int{}
 	out.i.SetBytes(q.i.Bytes())
 }
 

--- a/eth/quantity_test.go
+++ b/eth/quantity_test.go
@@ -3,6 +3,7 @@ package eth_test
 import (
 	"encoding/json"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,5 +75,25 @@ func TestQuantityFromUInt64(t *testing.T) {
 		invalid, err := eth.NewQuantity("0")
 		require.Error(t, err)
 		require.Nil(t, invalid)
+	}
+}
+
+func TestQuantity_DeepCopyInto(t *testing.T) {
+	val := int64(0x123456)
+	src := eth.QuantityFromInt64(val)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			// This is basically the same pattern as the auto-generated eth.Block.DeepCopy
+			// code here: https://github.com/INFURA/go-ethlibs/blob/master/eth/zz_deepcopy_generated.go#L19
+			cpy := src
+			src.DeepCopyInto(&cpy)
+
+			if cpy.Int64() != val {
+				panic("not equal")
+			}
+		}()
 	}
 }


### PR DESCRIPTION
The issue was that Block.DeepCopy autogenerates code like:

```
*out := *in
in.Difficulty.DeepCopyInto(&out.Difficulty)
```

See: https://github.com/INFURA/go-ethlibs/blob/master/eth/zz_deepcopy_generated.go#L19

However, our hand-written `Quantity.DeepCopyInto` wasn't fully resetting the embedded `big.Int`, and `big.Int.nat.abs` is a `[]Word` slice so was being re-used, which could lead to data races if the blocks were accessed on different go-routines.