### PR TITLE
eth.Transaction: Make the input validation for .FromRaw and .Sign more robust

### DIFF
--- a/eth/transaction_from_raw.go
+++ b/eth/transaction_from_raw.go
@@ -92,7 +92,7 @@ func (t *Transaction) FromRaw(input string) error {
 		return nil
 	case firstByte > 0x7f:
 		// In EIP-2718 types larger than 0x7f are reserved since they potentially conflict with legacy RLP encoded
-		// transactions.  As such we can attempt to decoded any such transactions as legacy format and attempt to
+		// transactions.  As such we can attempt to decode any such transactions as legacy format and attempt to
 		// decode the input string as an rlp.Value
 		if err := rlpDecodeList(input, &nonce, &gasPrice, &gasLimit, &to, &value, &data, &v, &r, &s); err != nil {
 			return errors.Wrap(err, "could not decode RLP components")

--- a/eth/transaction_from_raw.go
+++ b/eth/transaction_from_raw.go
@@ -32,8 +32,23 @@ func (t *Transaction) FromRaw(input string) error {
 		accessList AccessList
 	)
 
+	if !strings.HasPrefix(input, "0x") {
+		return errors.New("input must start with 0x")
+	}
+
+	if len(input) < 4 {
+		return errors.New("not enough input to decode")
+	}
+
+	var firstByte byte
+	if prefix, err := NewData(input[:4]); err != nil {
+		return errors.Wrap(err, "could not inspect transaction prefix")
+	} else {
+		firstByte = prefix.Bytes()[0]
+	}
+
 	switch {
-	case strings.HasPrefix(input, "0x01"):
+	case firstByte == 0x01:
 		// EIP-2930 transaction
 		payload := "0x" + input[4:]
 		if err := rlpDecodeList(payload, &chainId, &nonce, &gasPrice, &gasLimit, &to, &value, &data, &accessList, &v, &r, &s); err != nil {
@@ -75,9 +90,10 @@ func (t *Transaction) FromRaw(input string) error {
 		t.Hash = raw.Hash()
 		t.From = *sender
 		return nil
-	default:
-		// Legacy Transaction
-		// Decode the input string as an rlp.Value
+	case firstByte > 0x7f:
+		// In EIP-2718 types larger than 0x7f are reserved since they potentially conflict with legacy RLP encoded
+		// transactions.  As such we can attempt to decoded any such transactions as legacy format and attempt to
+		// decode the input string as an rlp.Value
 		if err := rlpDecodeList(input, &nonce, &gasPrice, &gasLimit, &to, &value, &data, &v, &r, &s); err != nil {
 			return errors.Wrap(err, "could not decode RLP components")
 		}
@@ -126,6 +142,8 @@ func (t *Transaction) FromRaw(input string) error {
 		t.Hash = raw.Hash()
 		t.From = *sender
 		return nil
+	default:
+		return errors.New("unsupported transaction type")
 	}
 }
 

--- a/eth/transaction_from_raw_test.go
+++ b/eth/transaction_from_raw_test.go
@@ -17,6 +17,72 @@ func TestTransaction_FromRaw(t *testing.T) {
 	require.Equal(t, eth.MustAddress("0x6bc84f6a0fabbd7102be338c048fe0ae54948c2e").String(), tx.From.String())
 }
 
+func TestTransaction_FromRaw_Invalid_Payloads(t *testing.T) {
+	{
+		input := `0x7f00000000`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "unsupported transaction type", err.Error())
+	}
+
+	{
+		input := `8000`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "input must start with 0x", err.Error())
+	}
+
+	{
+		input := `0x`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "not enough input to decode", err.Error())
+	}
+
+	{
+		input := `0x1`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "not enough input to decode", err.Error())
+	}
+
+	{
+		input := `0x01`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "could not decode RLP components: expected 11 items but only received 0", err.Error())
+	}
+
+	{
+		input := `0x0180`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "could not decode RLP components: expected 11 items but only received 0", err.Error())
+	}
+
+	{
+		input := `0x80`
+		tx := eth.Transaction{}
+		err := tx.FromRaw(input)
+		require.Error(t, err)
+		require.Equal(t, "could not decode RLP components: expected 9 items but only received 0", err.Error())
+	}
+
+	{
+		unsigned := "0x01f86587796f6c6f76337880843b9aca008262d494df0a88b2b68c673713a8ec826003676f272e35730180f838f7940000000000000000000000000000000000001337e1a00000000000000000000000000000000000000000000000000000000000000000808080"
+		tx := eth.Transaction{}
+		err := tx.FromRaw(unsigned)
+		require.Error(t, err)
+		require.Equal(t, "unsigned transactions not supported", err.Error())
+	}
+}
+
 func TestTransaction_FromRawEIP2930_Unsigned(t *testing.T) {
 	input := "0x01f85c82053901018262d4940993cb059574b88c78849139cb91f7d85f8f289a8080f838f7940000000000000000000000000000000000001337e1a00000000000000000000000000000000000000000000000000000000000000001808080"
 	tx := eth.Transaction{}

--- a/eth/transaction_signing.go
+++ b/eth/transaction_signing.go
@@ -37,6 +37,9 @@ func (t *Transaction) Sign(privateKey string, chainId Quantity) (*Data, error) {
 
 	// Get the data to sign, which is a hash of the type-dependent fields
 	hash, err := t.SigningHash(chainId)
+	if err != nil {
+		return nil, err
+	}
 
 	// And sign the hash with the key
 	signature, err := ECSign(hash, pKey, chainId)

--- a/eth/transaction_signing_test.go
+++ b/eth/transaction_signing_test.go
@@ -168,3 +168,15 @@ func TestTransaction_Sign_EIP2930(t *testing.T) {
 	require.Equal(t, "0xbe950468ba1c25a5cb50e9f6d8aa13c8cd21f24ba909402775b262ac76d374d", tx.S.String())
 	require.Equal(t, "0x0", tx.V.String())
 }
+
+func TestTransaction_Sign_InvalidTxType(t *testing.T) {
+	tx := eth.Transaction{
+		Type: eth.MustQuantity("0x7f"),
+	}
+
+	chainId := eth.QuantityFromInt64(0x796f6c6f763378)
+	signed, err := tx.Sign("fad9c8855b740a0b7ed4c221dbad0f33a83a49cad6b3fe8d5817ac83d38b6a19", chainId)
+	require.Nil(t, signed)
+	require.Error(t, err)
+	require.Equal(t, "unsupported transaction type", err.Error())
+}


### PR DESCRIPTION
I was re-reviewing my `.Sign` changes and noticed that I left out an error check, which could lead to a panic on unsupported tx types (unit added to cover this case now).  

This in turn made me revisit `.FromRaw` since I noticed it didn't fully follow the EIP-2718 spec when inspecting the first byte, so I refactored that a bit as well.  The net result is that `FromRaw` now returns more informative/correct errors instead of trying to decode all non-EIP-2930 txs as legacy txs.