### PR TITLE
Transaction Signing Refactor

### DIFF
--- a/eth/data.go
+++ b/eth/data.go
@@ -307,6 +307,13 @@ func validateHex(value string, size int, typ string) (string, error) {
 	return value, nil
 }
 
+// RLP returns the Data as an RLP-encoded string.
+func (d *Data) RLP() rlp.Value {
+	return rlp.Value{
+		String: d.String(),
+	}
+}
+
 // RLP returns the Data32 as an RLP-encoded string.
 func (d *Data32) RLP() rlp.Value {
 	return rlp.Value{

--- a/eth/signature.go
+++ b/eth/signature.go
@@ -119,10 +119,14 @@ func (s *Signature) EIP2718Values() (R Quantity, S Quantity, V Quantity) {
 	return s.r, s.s, s.v
 }
 
+// Recover performs ECRecover on the supplied hash using the signatures R, S, and V values,
+// returning the sender Address or an error.
 func (s *Signature) Recover(hash *Hash) (*Address, error) {
 	return ECRecover(hash, &s.r, &s.s, &s.v)
 }
 
+// ChainId returns the chain id included in the signature, or an error if signature was created with unprotected
+// pre-EIP-155 R, S, and V values.
 func (s *Signature) ChainId() (*Quantity, error) {
 	if s.chainId.Int64() == 0 {
 		return nil, errors.New("chainId was not provided")

--- a/eth/signature.go
+++ b/eth/signature.go
@@ -16,7 +16,55 @@ type Signature struct {
 	chainId Quantity
 }
 
-// ECSign returns the R,S, and V values for a given message hash for the given chainId using the bytes of given
+// NewEIP2718Signature creates a new Signature from discrete chainId, R, S, and V values.
+func NewEIP2718Signature(chainId Quantity, r Quantity, s Quantity, v Quantity) (*Signature, error) {
+	if chainId.Int64() == 0 {
+		return nil, errors.New("chainId is required for EIP-2718 style signatures")
+	}
+	if vi := v.Int64(); vi > 1 || vi < 0 {
+		return nil, errors.New("v must be 0x0 or 0x1 for EIP-2718 style signatures")
+	}
+
+	sig := Signature{
+		r:       r,
+		s:       s,
+		v:       v,
+		chainId: chainId,
+	}
+	return &sig, nil
+}
+
+// NewEIP155Signature creates a new Signature from EIP-155 packed R,S,V values
+func NewEIP155Signature(r Quantity, s Quantity, v Quantity) (*Signature, error) {
+	sig := Signature{
+		r: r,
+		s: s,
+		v: v,
+	}
+	// Unpack the passed in v into "standard" v and chainId
+	vi := v.Int64()
+	switch {
+	case vi == 27 || vi == 28:
+		sig.v = QuantityFromInt64(vi - 27)
+		sig.chainId = QuantityFromInt64(0)
+		return &sig, nil
+	case vi == 0 || vi == 1:
+		sig.v = QuantityFromInt64(vi)
+		sig.chainId = QuantityFromInt64(0)
+		return &sig, nil
+	case vi >= 35:
+		// Pull out chainId and recoveryV from EIP-155 packed V
+		_chainId := (vi - 35) / 2
+		_v := (vi - 27) - ((_chainId * 2) + 8)
+		sig.chainId = QuantityFromInt64(_chainId)
+		sig.v = QuantityFromInt64(_v)
+		return &sig, nil
+	default:
+		return nil, errors.New("unexpected EIP-155 V value")
+	}
+}
+
+// ECSign returns the signature values for a given message hash for the given chainId using the bytes of given
 // private key.  Primarily used to sign transactions before submitting them with eth_sendRawTransaction.
 func ECSign(h *Hash, privKeyBytes []byte, chainId Quantity) (*Signature, error) {
 	// code for this method inspired by https://github.com/ethereumjs/ethereumjs-util/blob/master/src/signature.ts#L15
@@ -69,6 +117,18 @@ func (s *Signature) EIP155Values() (R Quantity, S Quantity, V Quantity) {
 // or 0x1 parity bit.
 func (s *Signature) EIP2718Values() (R Quantity, S Quantity, V Quantity) {
 	return s.r, s.s, s.v
+}
+
+func (s *Signature) Recover(hash *Hash) (*Address, error) {
+	return ECRecover(hash, &s.r, &s.s, &s.v)
+}
+
+func (s *Signature) ChainId() (*Quantity, error) {
+	if s.chainId.Int64() == 0 {
+		return nil, errors.New("chainId was not provided")
+	}
+	chainId := s.chainId
+	return &chainId, nil
 }
 
 // ECRecover returns the sending address, given a message digest and R, S, V values.

--- a/eth/transaction_from_raw.go
+++ b/eth/transaction_from_raw.go
@@ -14,9 +14,11 @@ import (
 // after EIP-2718 the payload format depends on the transaction type included as the first byte.
 // Unsigned transactions where R, S, and V are zero are not currently supported.
 func (t *Transaction) FromRaw(input string) error {
-	// Code is heavily inspired by ethers.js utils.transaction.parse:
-	// https://github.com/ethers-io/ethers.js/blob/master/utils/transaction.js#L90
+	// Code was originally heavily inspired by ethers.js v4 utils.transaction.parse:
+	// https://github.com/ethers-io/ethers.js/blob/v4-legacy/utils/transaction.js#L90
 	// Copyright (c) 2017 Richard Moore
+	//
+	// However it's since been somewhat extensively rewritten to support EIP-2718 and -2930
 
 	var (
 		chainId    Quantity

--- a/eth/transaction_from_raw.go
+++ b/eth/transaction_from_raw.go
@@ -55,6 +55,10 @@ func (t *Transaction) FromRaw(input string) error {
 			return errors.Wrap(err, "could not decode RLP components")
 		}
 
+		if r.Int64() == 0 && s.Int64() == 0 {
+			return errors.New("unsigned transactions not supported")
+		}
+
 		t.Type = MustQuantity("0x1")
 		t.Nonce = nonce
 		t.GasPrice = gasPrice
@@ -73,16 +77,17 @@ func (t *Transaction) FromRaw(input string) error {
 			return err
 		}
 
-		if r.Int64() == 0 && s.Int64() == 0 {
-			return errors.New("unsigned transactions not supported")
-		}
-
-		sender, err := ECRecover(signingHash, &r, &s, &v)
+		signature, err := NewEIP2718Signature(chainId, r, s, v)
 		if err != nil {
 			return err
 		}
 
-		raw, err := t.RawRepresentation(chainId)
+		sender, err := signature.Recover(signingHash)
+		if err != nil {
+			return err
+		}
+
+		raw, err := t.RawRepresentation()
 		if err != nil {
 			return err
 		}
@@ -98,6 +103,10 @@ func (t *Transaction) FromRaw(input string) error {
 			return errors.Wrap(err, "could not decode RLP components")
 		}
 
+		if r.Int64() == 0 && s.Int64() == 0 {
+			return errors.New("unsigned transactions not supported")
+		}
+
 		// ... and fill in all our fields with the decoded values
 		t.Nonce = nonce
 		t.GasPrice = gasPrice
@@ -109,32 +118,22 @@ func (t *Transaction) FromRaw(input string) error {
 		t.R = r
 		t.S = s
 
-		// Pull out chainId and recoveryV from EIP-155 packed V
-		_chain := (v.Int64() - 35) / 2
-		if _chain < 0 {
-			_chain = 0
-		}
-
-		_recovery := v.Int64() - 27
-		if _chain != 0 {
-			// And subtract out the chainId to get a proper recovery value
-			_recovery -= (_chain * 2) + 8
-		}
-
-		recoveryV := QuantityFromInt64(_recovery)
-		chainId = QuantityFromInt64(_chain)
-
-		signingHash, err := t.SigningHash(chainId)
+		signature, err := NewEIP155Signature(r, s, v)
 		if err != nil {
 			return err
 		}
 
-		sender, err := ECRecover(signingHash, &r, &s, &recoveryV)
+		signingHash, err := t.SigningHash(signature.chainId)
 		if err != nil {
 			return err
 		}
 
-		raw, err := t.RawRepresentation(chainId)
+		sender, err := signature.Recover(signingHash)
+		if err != nil {
+			return err
+		}
+
+		raw, err := t.RawRepresentation()
 		if err != nil {
 			return err
 		}

--- a/eth/transaction_from_raw_test.go
+++ b/eth/transaction_from_raw_test.go
@@ -170,6 +170,21 @@ func TestTransaction_FromRaw_EIP155_Examples(t *testing.T) {
 	}
 }
 
+func TestTransaction_FromRaw_Unprotected(t *testing.T) {
+	// Verify that we can correctly parse a non-EIP-155 transaction, we use an example from a pre-EIP-155 version of Truffle
+	rawInput := `0xf9024f808504a817c800836691b78080b901fc608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061019c806100606000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c8063445df0ac146100465780638da5cb5b14610064578063fdacd576146100ae575b600080fd5b61004e6100dc565b6040518082815260200191505060405180910390f35b61006c6100e2565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100da600480360360208110156100c457600080fd5b8101908080359060200190929190505050610107565b005b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561016457806001819055505b5056fea265627a7a7231582029c98913dbb8a328d702e923ba85e26be47ea5e754908b3b671db0350327939a64736f6c634300051000321ca03cf2a8f67ed9ce210f3da5b95ef2121069c22e1370a2419967316adc4c36e3f1a06dd8fb33a6b7e8789d15877764622fe8af96ba1808c0f71634abccc37ad3e31c`
+	tx := eth.Transaction{}
+	err := tx.FromRaw(rawInput)
+	require.NoError(t, err)
+	// Unprotected transaction should have a non-EIP-155 V value, so 27 or 28 rather than `CHAIN_ID * 2 + 35` or `CHAIN_ID * 2 + 36`
+	require.Equal(t, int64(28), tx.V.Int64())
+	// convert back to raw, we can use any chainId since this is a legacy tx
+	chainId := eth.QuantityFromInt64(0xbadf00d)
+	rawOutput, err := tx.RawRepresentation(chainId)
+	require.NoError(t, err)
+	require.Equal(t, rawInput, rawOutput.String())
+}
+
 func TestTransaction_FromRaw_Samples(t *testing.T) {
 	for i, sample := range samples {
 		tx := eth.Transaction{}

--- a/eth/transaction_signing.go
+++ b/eth/transaction_signing.go
@@ -52,7 +52,7 @@ func (t *Transaction) Sign(privateKey string, chainId Quantity) (*Data, error) {
 	case TransactionTypeLegacy:
 		t.R, t.S, t.V = signature.EIP155Values()
 	case TransactionTypeAccessList:
-		// set RSV to EIP2718 values
+		// set chainId and RSV to EIP2718 values
 		t.ChainId = &chainId
 		t.R, t.S, t.V = signature.EIP2718Values()
 	default:

--- a/eth/transaction_signing_test.go
+++ b/eth/transaction_signing_test.go
@@ -1,6 +1,7 @@
 package eth_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,12 +31,28 @@ func TestTransaction_Sign(t *testing.T) {
 	tx2 := eth.Transaction{}
 	err = tx2.FromRaw(signed.String())
 	require.NoError(t, err)
+
+	jtx, err := json.Marshal(tx)
+	require.NoError(t, err)
+	jtx2, err := json.Marshal(tx2)
+	require.NoError(t, err)
+	require.JSONEq(t, string(jtx), string(jtx2))
+
+	require.Equal(t, tx2.From.String(), "0x96216849c49358B10257cb55b28eA603c874b05E")
+	require.Equal(t, tx.From, tx2.From)
 	require.Equal(t, tx2.Nonce.UInt64(), uint64(0))
 	require.Equal(t, tx2.GasPrice, eth.QuantityFromInt64(21488430592))
 	require.Equal(t, tx2.Gas, eth.QuantityFromInt64(90000))
 	require.Equal(t, tx2.To.String(), "0xc149Be1bcDFa69a94384b46A1F91350E5f81c1AB")
 	require.Equal(t, tx2.Value, eth.QuantityFromInt64(950000000000000000))
 	require.Equal(t, tx.Hash.String(), tx2.Hash.String())
+
+	signature, err := tx2.Signature()
+	require.NoError(t, err)
+
+	_chainId, err := signature.ChainId()
+	require.NoError(t, err)
+	require.Equal(t, chainId, *_chainId)
 }
 
 func TestTransaction_Sign_2(t *testing.T) {
@@ -56,12 +73,28 @@ func TestTransaction_Sign_2(t *testing.T) {
 	tx2 := eth.Transaction{}
 	err = tx2.FromRaw(signed.String())
 	require.NoError(t, err)
+
+	jtx, err := json.Marshal(tx)
+	require.NoError(t, err)
+	jtx2, err := json.Marshal(tx2)
+	require.NoError(t, err)
+	require.JSONEq(t, string(jtx), string(jtx2))
+
+	require.Equal(t, tx2.From.String(), "0x96216849c49358B10257cb55b28eA603c874b05E")
+	require.Equal(t, tx.From, tx2.From)
 	require.Equal(t, tx2.Nonce, eth.QuantityFromInt64(146))
 	require.Equal(t, tx2.GasPrice, eth.QuantityFromInt64(3000000000))
 	require.Equal(t, tx2.Gas, eth.QuantityFromInt64(22000))
 	require.Equal(t, tx2.To.String(), "0x43700db832E9Ac990D36d6279A846608643c904E")
 	require.Equal(t, tx2.Value, eth.QuantityFromInt64(1000000000))
 	require.Equal(t, tx.Hash.String(), tx2.Hash.String())
+
+	signature, err := tx2.Signature()
+	require.NoError(t, err)
+
+	_chainId, err := signature.ChainId()
+	require.NoError(t, err)
+	require.Equal(t, chainId, *_chainId)
 }
 
 // compares signed output created in python script
@@ -83,6 +116,27 @@ func TestTransaction_Sign_3(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, raw.String(), signed.String())
+
+	// check tx can be restored from rawtx
+	tx2 := eth.Transaction{}
+	err = tx2.FromRaw(signed.String())
+	require.NoError(t, err)
+
+	jtx, err := json.Marshal(tx)
+	require.NoError(t, err)
+	jtx2, err := json.Marshal(tx2)
+	require.NoError(t, err)
+	require.JSONEq(t, string(jtx), string(jtx2))
+
+	require.Equal(t, tx2.From.String(), "0x96216849c49358B10257cb55b28eA603c874b05E")
+	require.Equal(t, tx.From, tx2.From)
+
+	signature, err := tx2.Signature()
+	require.NoError(t, err)
+
+	_chainId, err := signature.ChainId()
+	require.NoError(t, err)
+	require.Equal(t, chainId, *_chainId)
 }
 
 func TestTransaction_Sign_EIP2930(t *testing.T) {
@@ -138,6 +192,7 @@ func TestTransaction_Sign_EIP2930(t *testing.T) {
 	*/
 	tx := eth.Transaction{
 		Type:     eth.MustQuantity("0x1"),
+		ChainId:  &chainId,
 		Gas:      eth.QuantityFromInt64(0x62d4),
 		GasPrice: eth.QuantityFromInt64(0x3b9aca00),
 		Input:    eth.Data("0x"),
@@ -155,7 +210,7 @@ func TestTransaction_Sign_EIP2930(t *testing.T) {
 	}
 
 	expectedUnsigned := "0x01f86587796f6c6f76337880843b9aca008262d494df0a88b2b68c673713a8ec826003676f272e35730180f838f7940000000000000000000000000000000000001337e1a00000000000000000000000000000000000000000000000000000000000000000808080"
-	unsigned, err := tx.RawRepresentation(chainId)
+	unsigned, err := tx.RawRepresentation()
 	require.NoError(t, err)
 	require.Equal(t, expectedUnsigned, unsigned.String())
 
@@ -187,13 +242,23 @@ func TestTransaction_Sign_EIP2930(t *testing.T) {
 	require.Equal(t, expectedSigned, signed.String())
 
 	// And verify that .From, .Hash, .R, .S., and .V are all set and match the geth console output
-	// TODO: Transaction.Sign doesn't actually call ECRecover on the key.  To do this we need to refactor out the
-	// EIP-155 V calculations a bit more, sine they are currently buried inside .FromRaw's Legacy case
 	require.Equal(t, *eth.MustAddress("0x96216849c49358b10257cb55b28ea603c874b05e"), tx.From)
 	require.Equal(t, "0xbbd570a3c6acc9bb7da0d5c0322fe4ea2a300db80226f7df4fef39b2d6649eec", tx.Hash.String())
 	require.Equal(t, "0x294ac94077b35057971e6b4b06dfdf55a6fbed819133a6c1d31e187f1bca938d", tx.R.String())
 	require.Equal(t, "0xbe950468ba1c25a5cb50e9f6d8aa13c8cd21f24ba909402775b262ac76d374d", tx.S.String())
 	require.Equal(t, "0x0", tx.V.String())
+
+	// Double check signature is still valid
+	tx2 := eth.Transaction{}
+	err = tx2.FromRaw(signed.String())
+	require.NoError(t, err)
+
+	signature, err := tx2.Signature()
+	require.NoError(t, err)
+
+	_chainId, err := signature.ChainId()
+	require.NoError(t, err)
+	require.Equal(t, chainId, *_chainId)
 }
 
 func TestTransaction_Sign_InvalidTxType(t *testing.T) {


### PR DESCRIPTION
This PR does a cleanup pass on our signing ergonomics and fixes a few bugs along the way.  It turned into a rather large PR since it required changing to the signing and from raw processes.  The main goal is was to make the final code easier to follow and hopefully will make implementing new transaction types (e.g. EIP-1559) easier going forward.

- Adds a new `Transaction.SigningPreimage` function which helps make the code a little easier to read and test
- Moves the ChainId packing/unpacking and ECRecover functionality into `Signature` which enables
- Fixing a bug where `Transaction.From` was not set after calling `Transaction.Sign`
- Also fixes a regression where we were letting unsigned legacy txs get further along in the code than previously
- Adds `Transaction.Signature()` for extracting out the correct `Signature` from a transaction object.  This is used in the tests to confirm that the transactions created from `.FromRaw` and `.Sign` have the correct chain id.
- Ensures that EIP-2718 txs always have `.ChainId` set before signing them
- Removes the need to pass `chainId` into `RawRepresentation` since we can rely on `tx.ChainId` being set when needed
- Adds a lot more validation to the `.Sign` and `.FromRaw` unit tests.
