### PR TITLE
Add eth.Transaction.IsProtected method

### DIFF
--- a/eth/transaction_from_raw_test.go
+++ b/eth/transaction_from_raw_test.go
@@ -25,6 +25,8 @@ func TestTransaction_FromRaw(t *testing.T) {
 	chainId, err := signature.ChainId()
 	require.NoError(t, err)
 	require.Equal(t, eth.QuantityFromInt64(42), *chainId)
+
+	require.True(t, tx.IsProtected())
 }
 
 func TestTransaction_FromRaw_Invalid_Payloads(t *testing.T) {
@@ -124,6 +126,8 @@ func TestTransaction_FromRawEIP2930(t *testing.T) {
 		rep, err := tx.RawRepresentation()
 		require.NoError(t, err)
 		require.Equal(t, raw, rep.String())
+
+		require.True(t, tx.IsProtected())
 	}
 }
 
@@ -156,6 +160,8 @@ func TestTransaction_FromRawEIP2930_YoloV3_NetherMind(t *testing.T) {
 		_chainId, err := signature.ChainId()
 		require.NoError(t, err)
 		require.Equal(t, chainId, _chainId)
+
+		require.True(t, tx.IsProtected())
 	}
 }
 
@@ -190,6 +196,8 @@ func TestTransaction_FromRaw_EIP155_Examples(t *testing.T) {
 		chainId, err := signature.ChainId()
 		require.NoError(t, err)
 		require.Equal(t, eth.QuantityFromInt64(0x1), *chainId)
+
+		require.True(t, tx.IsProtected())
 	}
 }
 
@@ -212,6 +220,8 @@ func TestTransaction_FromRaw_Unprotected(t *testing.T) {
 	chainId, err := signature.ChainId()
 	require.Error(t, err)
 	require.Nil(t, chainId)
+
+	require.False(t, tx.IsProtected())
 }
 
 func TestTransaction_FromRaw_Samples(t *testing.T) {

--- a/eth/transaction_signing.go
+++ b/eth/transaction_signing.go
@@ -199,6 +199,7 @@ func (t *Transaction) RawRepresentation() (*Data, error) {
 	}
 }
 
+// Signature returns the R, S, V values for a transaction, and the ChainId if available
 func (t *Transaction) Signature() (*Signature, error) {
 	switch t.TransactionType() {
 	case TransactionTypeLegacy:
@@ -211,4 +212,14 @@ func (t *Transaction) Signature() (*Signature, error) {
 	default:
 		return nil, errors.New("unsupported transaction type")
 	}
+}
+
+// IsProtected returns true if a transaction is replay protected, either via EIP-155 or newer transaction formats.
+// This method returns false for transactions with invalid signatures.
+func (t *Transaction) IsProtected() bool {
+	signature, err := t.Signature()
+	if err != nil {
+		return false
+	}
+	return signature.chainId.Int64() != 0x0
 }

--- a/eth/transaction_signing_test.go
+++ b/eth/transaction_signing_test.go
@@ -53,6 +53,8 @@ func TestTransaction_Sign(t *testing.T) {
 	_chainId, err := signature.ChainId()
 	require.NoError(t, err)
 	require.Equal(t, chainId, *_chainId)
+
+	require.True(t, tx2.IsProtected())
 }
 
 func TestTransaction_Sign_2(t *testing.T) {
@@ -95,6 +97,8 @@ func TestTransaction_Sign_2(t *testing.T) {
 	_chainId, err := signature.ChainId()
 	require.NoError(t, err)
 	require.Equal(t, chainId, *_chainId)
+
+	require.True(t, tx2.IsProtected())
 }
 
 // compares signed output created in python script
@@ -137,6 +141,8 @@ func TestTransaction_Sign_3(t *testing.T) {
 	_chainId, err := signature.ChainId()
 	require.NoError(t, err)
 	require.Equal(t, chainId, *_chainId)
+
+	require.True(t, tx2.IsProtected())
 }
 
 func TestTransaction_Sign_EIP2930(t *testing.T) {
@@ -259,6 +265,8 @@ func TestTransaction_Sign_EIP2930(t *testing.T) {
 	_chainId, err := signature.ChainId()
 	require.NoError(t, err)
 	require.Equal(t, chainId, *_chainId)
+
+	require.True(t, tx2.IsProtected())
 }
 
 func TestTransaction_Sign_InvalidTxType(t *testing.T) {


### PR DESCRIPTION
This PR adds a simple `eth.Transaction.IsProtected() bool` method  that transaction consumers can use to ensure they are only processing transactions protected by EIP-155 or later protection mechanisms (e.g. all EIP-2930 txs are inherently replay protected since the chainId is included as a discrete field).

Also added a docstring to `eth.Transaction.Signature` that I missed in my last PR. 😊 