### PR TITLE
Add ChainId

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -163,6 +163,32 @@ func (c *client) NetVersion(ctx context.Context) (string, error) {
 	return version, nil
 }
 
+func (c *client) ChainId(ctx context.Context) (string, error) {
+	request := jsonrpc.Request{
+		ID:     jsonrpc.ID{Num: 1},
+		Method: "eth_chainId",
+		Params: nil,
+	}
+
+	applyContext(ctx, &request)
+	response, err := c.Request(ctx, &request)
+	if err != nil {
+		return "", errors.Wrap(err, "could not make request")
+	}
+
+	if response.Error != nil {
+		return "", errors.New(string(*response.Error))
+	}
+
+	chainId := ""
+	err = json.Unmarshal(response.Result, &chainId)
+	if err != nil {
+		return "", errors.Wrap(err, "could not decode result")
+	}
+
+	return chainId, nil
+}
+
 func (c *client) BlockByNumber(ctx context.Context, number uint64, full bool) (*eth.Block, error) {
 	n := eth.QuantityFromUInt64(number)
 

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -28,8 +28,11 @@ type Client interface {
 	// BlockNumber returns the current block number at head
 	BlockNumber(ctx context.Context) (uint64, error)
 
-	// NetVersion returns the chain id
+	// NetVersion returns the netversion
 	NetVersion(ctx context.Context) (string, error)
+
+	// ChainId returns the chain id
+	ChainId(ctx context.Context) (string, error)
 
 	// EstimateGas returns the estimate gas
 	EstimateGas(ctx context.Context, msg eth.Transaction) (uint64, error)

--- a/node/ropsten_test.go
+++ b/node/ropsten_test.go
@@ -86,6 +86,15 @@ func TestConnection_NetVersion(t *testing.T) {
 	require.NotEmpty(t, netVersion, "net version id must not be nil")
 }
 
+func TestConnection_ChainId(t *testing.T) {
+	ctx := context.Background()
+	conn := getRopstenClient(t, ctx)
+
+	chainId, err := conn.ChainId(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, chainId, "chain id must not be nil")
+}
+
 func TestConnection_SendRawTransactionInValidEmpty(t *testing.T) {
 	ctx := context.Background()
 	conn := getRopstenClient(t, ctx)


### PR DESCRIPTION
Small PR for adding ChainId support to go-ethlibs. 

`go test node/ropsten_test.go -v`

<details>

```bash

➜  go-ethlibs git:(add-chain-id-rpc) ✗ go test node/ropsten_test.go -v
=== RUN   TestConnection_GetTransactionCount
--- PASS: TestConnection_GetTransactionCount (0.41s)
=== RUN   TestConnection_EstimateGas
--- PASS: TestConnection_EstimateGas (0.15s)
=== RUN   TestConnection_MaxPriorityFeePerGas
--- PASS: TestConnection_MaxPriorityFeePerGas (0.16s)
=== RUN   TestConnection_GasPrice
--- PASS: TestConnection_GasPrice (0.19s)
=== RUN   TestConnection_NetVersion
--- PASS: TestConnection_NetVersion (0.21s)
=== RUN   TestConnection_ChainId
--- PASS: TestConnection_ChainId (0.18s)
=== RUN   TestConnection_SendRawTransactionInValidEmpty
--- PASS: TestConnection_SendRawTransactionInValidEmpty (0.13s)
=== RUN   TestConnection_SendRawTransactionInValidOldNonce
--- PASS: TestConnection_SendRawTransactionInValidOldNonce (0.16s)
=== RUN   TestConnection_FutureBlockByNumber
--- PASS: TestConnection_FutureBlockByNumber (0.25s)
=== RUN   TestConnection_InvalidBlockByHash
--- PASS: TestConnection_InvalidBlockByHash (0.20s)
=== RUN   TestConnection_InvalidTransactionByHash
--- PASS: TestConnection_InvalidTransactionByHash (0.19s)
PASS
ok      command-line-arguments  2.389s
➜  go-ethlibs git:(add-chain-id-rpc) 

```

</details>