### PR TITLE
fix(node): use cloned DefaultTransport to setup correct default values

### DIFF
--- a/node/http.go
+++ b/node/http.go
@@ -56,9 +56,13 @@ func (t *httpTransport) IsBidirectional() bool {
 
 func (t *httpTransport) dispatchBytes(ctx context.Context, input []byte) ([]byte, error) {
 	t.once.Do(func() {
+		// Since this client is only ever used to access a single endpoint,
+		// we allow all the idle connections to point that host
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.MaxIdleConnsPerHost = tr.MaxIdleConns
 		t.client = &http.Client{
 			Timeout:   120 * time.Second,
-			Transport: &http.Transport{MaxIdleConnsPerHost: 100},
+			Transport: tr,
 		}
 	})
 


### PR DESCRIPTION
Previously the 0-value transport had `.IdleConnTimeout: 0` which means idle timeouts were disabled, and thus connections were only closed if the underlaying TCP connection timed out.  I also now copy the `MaxIdleConns` value since that was the semantic intent of setting the value to 100.