### PR TITLE
fix(jsonrpc):remove omitempty of Params fields in MarshalJSON()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:latest
+      - image: circleci/golang:1.12
     steps:
       - checkout
 

--- a/jsonrpc/request.go
+++ b/jsonrpc/request.go
@@ -65,6 +65,11 @@ func (r Request) MarshalJSON() ([]byte, error) {
 		JSONRPC: "2.0",
 	}
 	r2.ID = &r.ID
+
+	if r2.Params == nil {
+		r2.Params = make([]Param, 0)
+	}
+
 	return json.Marshal(r2)
 }
 
@@ -115,7 +120,7 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 func (r RequestWithNetwork) MarshalJSON() ([]byte, error) {
 	r2 := struct {
 		Method  string `json:"method"`
-		Params  Params `json:"params,omitempty"`
+		Params  Params `json:"params"`
 		ID      *ID    `json:"id,omitempty"`
 		JSONRPC string `json:"jsonrpc"`
 		Network string `json:"network"`

--- a/jsonrpc/request.go
+++ b/jsonrpc/request.go
@@ -120,7 +120,7 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 func (r RequestWithNetwork) MarshalJSON() ([]byte, error) {
 	r2 := struct {
 		Method  string `json:"method"`
-		Params  Params `json:"params"`
+		Params  Params `json:"params,omitempty"`
 		ID      *ID    `json:"id,omitempty"`
 		JSONRPC string `json:"jsonrpc"`
 		Network string `json:"network"`

--- a/jsonrpc/request.go
+++ b/jsonrpc/request.go
@@ -56,7 +56,7 @@ func MustRequest(id int, method string, params ...interface{}) *Request {
 func (r Request) MarshalJSON() ([]byte, error) {
 	r2 := struct {
 		Method  string `json:"method"`
-		Params  Params `json:"params,omitempty"`
+		Params  Params `json:"params"`
 		ID      *ID    `json:"id,omitempty"`
 		JSONRPC string `json:"jsonrpc"`
 	}{

--- a/jsonrpc/request_test.go
+++ b/jsonrpc/request_test.go
@@ -358,5 +358,9 @@ func TestMarshalGoodRequests(t *testing.T) {
 		}
 
 		assert.Equal(t, testCase.Expected, string(res), testCase.Description)
+
+		req := Request{}
+		err = json.Unmarshal(res, &req)
+		assert.NoError(t, err, "Got err '%v' unmarshal '%s'", err, string(res))
 	}
 }

--- a/jsonrpc/request_test.go
+++ b/jsonrpc/request_test.go
@@ -273,7 +273,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 	testCases := []TestCase{
 		{
 			Description: "String ID with No Params",
-			Expected:         `{"method":"eth_blockNumber","params":[],"id":"27a5fbbcaa23c1dcca4deb04f1501efb","jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":[],"id":"27a5fbbcaa23c1dcca4deb04f1501efb","jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Str:      "27a5fbbcaa23c1dcca4deb04f1501efb",
@@ -285,7 +285,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "Int ID with Empty Params",
-			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 42,
@@ -296,7 +296,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "Int ID with Null Params",
-			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 42,
@@ -307,7 +307,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "Int ID with Empty Params, but no JSONRPC version",
-			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 42,
@@ -318,7 +318,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "Int ID with Single Param",
-			Expected:         `{"method":"eth_blockNumber","params":["string"],"id":42,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":["string"],"id":42,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 42,
@@ -329,7 +329,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "Int ID with Single Object Param",
-			Expected:         `{"method":"eth_blockNumber","params":[{"foo":"bar"}],"id":42,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_blockNumber","params":[{"foo":"bar"}],"id":42,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 42,
@@ -340,7 +340,7 @@ func TestMarshalGoodRequests(t *testing.T) {
 		},
 		{
 			Description: "",
-			Expected:         `{"method":"eth_getBlockByNumber","params":["0x599784",true],"id":1839673506133526,"jsonrpc":"2.0"}`,
+			Expected:    `{"method":"eth_getBlockByNumber","params":["0x599784",true],"id":1839673506133526,"jsonrpc":"2.0"}`,
 			Request: &Request{
 				ID: ID{
 					Num: 1839673506133526,

--- a/jsonrpc/request_test.go
+++ b/jsonrpc/request_test.go
@@ -261,3 +261,102 @@ func TestRemarshalRequestWithNetworks(t *testing.T) {
 		assert.Equal(t, network, m.(map[string]interface{})["network"])
 	}
 }
+
+func TestMarshalGoodRequests(t *testing.T) {
+
+	type TestCase struct {
+		Description string
+		Expected    string
+		Request     *Request
+	}
+
+	testCases := []TestCase{
+		{
+			Description: "String ID with No Params",
+			Expected:         `{"method":"eth_blockNumber","params":[],"id":"27a5fbbcaa23c1dcca4deb04f1501efb","jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Str:      "27a5fbbcaa23c1dcca4deb04f1501efb",
+					IsString: true,
+				},
+				Method: "eth_blockNumber",
+				Params: nil,
+			},
+		},
+		{
+			Description: "Int ID with Empty Params",
+			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 42,
+				},
+				Method: "eth_blockNumber",
+				Params: Params{},
+			},
+		},
+		{
+			Description: "Int ID with Null Params",
+			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 42,
+				},
+				Method: "eth_blockNumber",
+				Params: nil,
+			},
+		},
+		{
+			Description: "Int ID with Empty Params, but no JSONRPC version",
+			Expected:         `{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 42,
+				},
+				Method: "eth_blockNumber",
+				Params: Params{},
+			},
+		},
+		{
+			Description: "Int ID with Single Param",
+			Expected:         `{"method":"eth_blockNumber","params":["string"],"id":42,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 42,
+				},
+				Method: "eth_blockNumber",
+				Params: MustParams("string"),
+			},
+		},
+		{
+			Description: "Int ID with Single Object Param",
+			Expected:         `{"method":"eth_blockNumber","params":[{"foo":"bar"}],"id":42,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 42,
+				},
+				Method: "eth_blockNumber",
+				Params: MustParams(map[string]string{"foo": "bar"}),
+			},
+		},
+		{
+			Description: "",
+			Expected:         `{"method":"eth_getBlockByNumber","params":["0x599784",true],"id":1839673506133526,"jsonrpc":"2.0"}`,
+			Request: &Request{
+				ID: ID{
+					Num: 1839673506133526,
+				},
+				Method: "eth_getBlockByNumber",
+				Params: MustParams("0x599784", true),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		res, err := json.Marshal(testCase.Request)
+		if assert.NoError(t, err, "Got err '%v' marshal '%q'", err, testCase.Expected) == false {
+			continue
+		}
+
+		assert.Equal(t, testCase.Expected, string(res), testCase.Description)
+	}
+}


### PR DESCRIPTION
Using this package in Palm user facing monitoring and I use it in blockNumber() to compare with the BlockNumber from Palm explorer
Tried to send a request without Params and I had that error "Method, params, and jsonrpc, are all required parameters" 
Then I add Params but same error because Params is nil 
I remove the omitempty from Params tags, the request's working
Then, I add unit test TestMarsalGoodRequests to confirm if in anycase I have Params[] and jsonrpc 2.0
This change should not have any impact on the other repo using this package

This PR is consistent with the API reference https://eth.wiki/json-rpc/API where params is always defined even if empty.