### PR TITLE
feat(block): add Celo flavor and Celo block type

### DIFF
--- a/eth/block.go
+++ b/eth/block.go
@@ -40,21 +40,21 @@ type Block struct {
 	SealFields *[]Data `json:"sealFields,omitempty"`
 
 	//Celo Specific Fields
-	Randomness     *Randomness     `json:"randomness,omitempty"`
-	EpochSnarkData *EpochSnarkData `json:"epochSnarkData,omitempty"`
+	Randomness     *Randomness     `json:"randomness"`
+	EpochSnarkData *EpochSnarkData `json:"epochSnarkData"`
 
 	// Track the flavor so we can re-encode correctly
 	flavor string
 }
 
 type Randomness struct {
-	Revealed  *Hash
-	Committed *Hash
+	Revealed  *Hash `json:"revealed"`
+	Committed *Hash `json:"committed"`
 }
 
 type EpochSnarkData struct {
-	Bitmap    *Quantity
-	Signature []byte
+	Bitmap    *Quantity `json:"bitmap"`
+	Signature []byte    `json:"signature"`
 }
 
 func (b *Block) DepopulateTransactions() {
@@ -324,8 +324,8 @@ func (b Block) MarshalJSON() ([]byte, error) {
 			GasUsed          Quantity        `json:"gasUsed"`
 			Timestamp        Quantity        `json:"timestamp"`
 			Transactions     []TxOrHash      `json:"transactions"`
-			Randomness       *Randomness     `json:"randomness,omitempty"`
-			EpochSnarkData   *EpochSnarkData `json:"epochSnarkData,omitempty"`
+			Randomness       *Randomness     `json:"randomness"`
+			EpochSnarkData   *EpochSnarkData `json:"epochSnarkData"`
 
 			BaseFeePerGas *Quantity `json:"baseFeePerGas,omitempty"`
 


### PR DESCRIPTION
EVM proxy indexers for Celo don't work, we have the same error 
`{"level":"error","ts":1669817783.848682,"caller":"proxy/indexer.go:43","msg":"headtracker stopped with error","error":"error getting starting block: error getting initial latest block from store: error unmarshalling blockbyhash from json: data types must start with 0x"`
the problem come from the celo block fields that trigger the error

**so for now the solution is to add a Celo flavor field to differentiate between clients.**

with this change on ethlibs, the EVM proxy indexers for Celo are working well :
`{"level":"info","ts":1669817554.114091,"caller":"headtracker/headtracker.go:266","msg":"block logs stored","blockNumber":14289075,"count":2}
{"level":"info","ts":1669817555.263482,"caller":"headtracker/headtracker.go:204","msg":"added block","blockNumber":14289075,"blockHash":"0x842c8b2ba67aeeee449c1b11920f640b47200d241dcf651f02bc959fb91da42f","reorg":false}
{"level":"info","ts":1669817558.268481,"caller":"headtracker/headtracker.go:266","msg":"block logs stored","blockNumber":14289076,"count":4}
{"level":"info","ts":1669817558.96629,"caller":"headtracker/headtracker.go:204","msg":"added block","blockNumber":14289076,"blockHash":"0x7ccc7feb8f9f7eaca8fb65237a30026e4949c41506073f607f4b478e46b610e6","reorg":false}`


