### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@ryanschneider @basgys @akuanti
+* @ryanschneider @basgys @akuanti


### PR DESCRIPTION
I think Github lies: 

![image](https://user-images.githubusercontent.com/53520/217971109-1ae10e27-840a-4678-b3a9-231e4f4d85b9.png)

I noticed no one was being tagged on my new PRs and I _think_ it's because the `*` was missing.. ?