### PR TITLE
eth.Transaction: support new yParity field

### DIFF
--- a/eth/transaction.go
+++ b/eth/transaction.go
@@ -32,6 +32,7 @@ type Transaction struct {
 	V           Quantity  `json:"v"`
 	R           Quantity  `json:"r"`
 	S           Quantity  `json:"s"`
+	YParity     *Quantity `json:"yParity,omitempty"`
 
 	// Gas Price (optional since not included in EIP-1559)
 	GasPrice *Quantity `json:"gasPrice,omitempty"`
@@ -161,6 +162,12 @@ func (t *Transaction) RawRepresentation() (*Data, error) {
 		if err != nil {
 			return nil, err
 		}
+		var yParity Quantity
+		if t.YParity != nil {
+			yParity = *t.YParity
+		} else {
+			yParity = t.V
+		}
 		payload := rlp.Value{List: []rlp.Value{
 			t.ChainId.RLP(),
 			t.Nonce.RLP(),
@@ -170,7 +177,7 @@ func (t *Transaction) RawRepresentation() (*Data, error) {
 			t.Value.RLP(),
 			{String: t.Input.String()},
 			t.AccessList.RLP(),
-			t.V.RLP(),
+			yParity.RLP(),
 			t.R.RLP(),
 			t.S.RLP(),
 		}}
@@ -185,6 +192,12 @@ func (t *Transaction) RawRepresentation() (*Data, error) {
 		if err != nil {
 			return nil, err
 		}
+		var yParity Quantity
+		if t.YParity != nil {
+			yParity = *t.YParity
+		} else {
+			yParity = t.V
+		}
 		payload := rlp.Value{List: []rlp.Value{
 			t.ChainId.RLP(),
 			t.Nonce.RLP(),
@@ -195,7 +208,7 @@ func (t *Transaction) RawRepresentation() (*Data, error) {
 			t.Value.RLP(),
 			{String: t.Input.String()},
 			t.AccessList.RLP(),
-			t.V.RLP(),
+			yParity.RLP(),
 			t.R.RLP(),
 			t.S.RLP(),
 		}}

--- a/eth/transaction_from_raw.go
+++ b/eth/transaction_from_raw.go
@@ -72,6 +72,7 @@ func (t *Transaction) FromRaw(input string) error {
 		t.Input = data
 		t.AccessList = &accessList
 		t.V = v
+		t.YParity = &v
 		t.R = r
 		t.S = s
 		t.ChainId = &chainId
@@ -121,6 +122,7 @@ func (t *Transaction) FromRaw(input string) error {
 		t.Input = data
 		t.AccessList = &accessList
 		t.V = v
+		t.YParity = &v
 		t.R = r
 		t.S = s
 		t.ChainId = &chainId
@@ -168,6 +170,7 @@ func (t *Transaction) FromRaw(input string) error {
 		t.Value = value
 		t.Input = data
 		t.V = v
+		t.YParity = nil
 		t.R = r
 		t.S = s
 

--- a/eth/transaction_from_raw_test.go
+++ b/eth/transaction_from_raw_test.go
@@ -120,6 +120,8 @@ func TestTransaction_FromRawEIP2930(t *testing.T) {
 		require.Equal(t, "0x1684eb52101a049f7bda9b0239dbd56db6735f8eed4207cdabd682dde3ed06bf", tx.R.String())
 		require.Equal(t, "0x71d5cf480a272dc907ff4a4efb2a4a96e2132409592268747acfa5d03f50deb7", tx.S.String())
 		require.Equal(t, "0x0", tx.V.String())
+		require.NotNil(t, tx.YParity)
+		require.Equal(t, "0x0", tx.YParity.String())
 		require.Equal(t, "0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192", tx.To.String())
 		require.Equal(t, "0x1", tx.Type.String())
 		require.Equal(t, int64(0), tx.Value.Int64())

--- a/eth/transaction_test.go
+++ b/eth/transaction_test.go
@@ -184,6 +184,7 @@ func TestTransactionTypeDynamicFee(t *testing.T) {
         "transactionIndex": "0x41",
         "value": "0x0",
         "v": "0x1",
+        "yParity": "0x1",
         "r": "0x396864e5f9132327defdb1449504252e1fa6bce73feb8cd6f348a342b198af34",
         "s": "0x44dbba72e6d3304104848277143252ee43627c82f02d1ef8e404e1bf97c70158",
         "gasPrice": "0x4a817c800",
@@ -206,6 +207,8 @@ func TestTransactionTypeDynamicFee(t *testing.T) {
 	require.NotNil(t, tx.Type)
 	require.Equal(t, eth.TransactionTypeDynamicFee, tx.Type.Int64())
 	require.Equal(t, eth.TransactionTypeDynamicFee, tx.TransactionType())
+	require.NotNil(t, tx.YParity)
+	require.Equal(t, tx.V, *tx.YParity)
 
 	j, err := json.Marshal(&tx)
 	require.NoError(t, err)

--- a/eth/zz_deepcopy_generated.go
+++ b/eth/zz_deepcopy_generated.go
@@ -476,6 +476,10 @@ func (in *Transaction) DeepCopyInto(out *Transaction) {
 	in.V.DeepCopyInto(&out.V)
 	in.R.DeepCopyInto(&out.R)
 	in.S.DeepCopyInto(&out.S)
+	if in.YParity != nil {
+		in, out := &in.YParity, &out.YParity
+		*out = (*in).DeepCopy()
+	}
 	if in.GasPrice != nil {
 		in, out := &in.GasPrice, &out.GasPrice
 		*out = (*in).DeepCopy()


### PR DESCRIPTION
Fixes #88.  This adds the `yParity` field (see https://github.com/ethereum/execution-apis/pull/446) that was added in geth 1.12.1 and possibly other eth clients as well.

Note that `tx.V` has been deprecated for newer tx types, so eventually we'll need to change it to a pointer w/ `omitempty` but I'll leave it as is for now, as I suspect #89 might require even larger refactors.